### PR TITLE
Allow multiple calls to Request::getContent()

### DIFF
--- a/Factory/DiactorosFactory.php
+++ b/Factory/DiactorosFactory.php
@@ -45,11 +45,11 @@ class DiactorosFactory implements HttpMessageFactoryInterface
         $server = DiactorosRequestFactory::normalizeServer($symfonyRequest->server->all());
         $headers = $symfonyRequest->headers->all();
 
-        try {
-            $body = new DiactorosStream($symfonyRequest->getContent(true));
-        } catch (\LogicException $e) {
+        if(PHP_VERSION_ID < 50600) {
             $body = new DiactorosStream('php://temp', 'wb+');
             $body->write($symfonyRequest->getContent());
+        } else {
+            $body = new DiactorosStream($symfonyRequest->getContent(true));
         }
 
         $request = new ServerRequest(


### PR DESCRIPTION
The Symfony request throws a LogicException if getContent() is called more than once and the first time with parameter "true" when using PHP versions older than 5.6. If ```$symfonyRequest->getContent(true)``` has thrown the exception, the call to ```$symfonyRequest->getContent()``` will do the same again.